### PR TITLE
docs: review portal docs

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -8,7 +8,7 @@ position: 0
 
 # Welcome to Fiddler Jam
 
-**Fiddler Jam** is a troubleshooting solution for support and development teams to help them troubleshoot issues quickly, easily, and securely. How does it work? Customers share network logs via a Chrome extension instead of manually attaching them to an email or a support ticket. The support team analyzes the logs for troubleshooting in a safe cloud space. Developers debug further by inspecting the logs in the [Fiddler Jam portal](https://jam.getfiddler.com) or with the help of Fiddler Everywhere application.
+**Fiddler Jam** is a troubleshooting solution for support and development teams designed to help them troubleshoot issues quickly, easily, and securely. How does it work? Customers share network logs via a Chrome extension instead of manually attaching them to an email or a support ticket. The support team analyzes the logs for troubleshooting in a safe cloud space. Developers debug further by inspecting the logs in the [Fiddler Jam portal](https://jam.getfiddler.com) or with the help of the Fiddler Everywhere application.
 
 **HTTP(S) Traffic Inspection & Analysis**
 
@@ -16,15 +16,15 @@ The Fiddler Jam Chrome extension logs all HTTP(S) traffic between your Chrome br
 
 **Screenshots on User Interactions**
 
-Extended log information with screenshots for each user interaction with the page (clicks) during the HTTP(S) traffic recording. Empower your recording with visual information related to specific reproduction workflows.
+The extended log information includes screenshots for each user interaction with the page (clicks) during the HTTP(S) traffic recording. Empower your recording with visual information related to specific reproduction workflows.
 
 **Record Developer Logs**
 
-Record the developer's console logs for additional debug information and to investiagte complex issues on-the-fly.
+Record the developer's console logs for additional debug information and for investigation of complex issues on-the-fly.
 
 **Cloud Space Submissions**
 
-Recorded logs can be easily submitted to the FIddler Jam portal where they can be saved, organized, analysed and shared with other collaborators. The Fiddler Jam cloud portal provide means to control accessability by providing access rights.
+Recorded logs can be easily submitted to the Fiddler Jam portal, where they can be saved, organized, analyzed, and shared with other collaborators. The Fiddler Jam cloud portal provides means to control accessibility by providing access rights.
 
 **Fiddler Everywhere Integration**
 
@@ -33,28 +33,37 @@ Submitted logs are compatible with Fiddler Everywhere for in-depth investigation
 
 ## Chrome Extension Getting Started
 
-Enable and properly configure the Fiddler Jam extension by following [the instalation steps]({%slug fj-installation%}).
+Enable and configure the Fiddler Jam extension by following [the installation steps]({%slug fj-installation%}).
 
-If you are familiar with how a Chrome extension works, you could skip the above tutorial and directly install the [Chrome extension](https://chrome.google.com/webstore/detail/fiddler-jam/fnkjlegmkbicdodlheligomlfbdblpfj) from the Google Chrome Extensions store.
+If you are familiar with how a Chrome extension works, you could skip the above tutorial and directly install the [Chrome extension](https://chrome.google.com/webstore/detail/fiddler-jam/fnkjlegmkbicdodlheligomlfbdblpfj) from the Google Chrome Web Store.
 
 
 ## Fiddler Jam Portal
 
-[The Fiddler Jam portal]({%slug fj-portal%}) is a cloud space to safely store, organaze and anaylize submitted logs coming from your customers. Some of the portal key features includes access right user roles, safe online storage and one-click integration with Fiddler Everywhere.
+[The Fiddler Jam portal]({%slug fj-portal%}) is a cloud space that allows you to safely store, organize and analyze submitted logs coming from your customers. Some of the portal's key features include:
+
+- User roles with different access rights.
+
+- Safe online storage.
+
+- One-click integration with Fiddler Everywhere.
 
 ## Documentation
 
 [Official Fiddler Jam documentation](https://docs.telerik.com/fiddler-jam/introduction)
 
-We believe documentation is best when the content is a product of collaboration between the builders and consumers of that product. Everybody can play a role in making our documentation better, and we encourage you to help us with that task in the way that you choose:
+We believe documentation is best when the content is a product of the collaboration between the builders and consumers of that product. Everybody can play a role in making our documentation better, and we encourage you to help us with that task in the way that you choose:
 
 - Send Feedback
+
     Use the __Was this article helpful?__ functionality to give us feedback and ideas on improving the documentation. Alternatively, you could request a feature or report a bug using the [Fiddler Everywhere Feedback Portal](https://feedback.telerik.com/fiddler-everywhere).
 
 - Create an Issue
+
     If you find an issue with our docs that needs addressing, the best way to let us know is by creating an issue in our [Github repository](https://github.com/telerik/fiddler-jam-docs). When creating an issue, please provide a descriptive title, be as specific as possible, and link it to the documentation article. If you can provide a link to the closest anchor to the issue, that is even better.
 
 - Send a Pull Request
+
     Creating an issue is excellent, but what we love are pull requests. If you find a problem in the docs or even feel like creating new content, we’d be happy to have your contributions! 
 
     To do this, you must fork our documentation and submit a pull request. That way, you may contribute an update exactly where you found the error. After that, our technical writing team will need to approve your change request. Please use only standard markdown. For more detailed instructions, please follow the [contribution instructions](https://github.com/telerik/fiddler-jam-docs#contributing) published in GitHub. You could directly initiate a pull request by using the __Improve this article__ functionality.

--- a/portal/fiddler-jam-portal.md
+++ b/portal/fiddler-jam-portal.md
@@ -8,7 +8,7 @@ position: 10
 
 # Fiddler Jam Portal
 
-The [Fiddler Jam portal](https://jam.getfiddler.com) is the cloud space where logs submitted from you or other users can be viewed, organized, and analyzed. The Fiddler Jam portal is accessible only for users with active [Fiddler Jam portal subscriptions](#subscriptions). The Fiddler Jam portal provides different means to organize, access, and work with submitted logs. The portal allows settings up different roles for the portal users with different access rights.
+The [Fiddler Jam portal](https://jam.getfiddler.com) is the cloud space where logs submitted from you or other users can be viewed, organized, and analyzed. The Fiddler Jam portal is accessible only for users with active [Fiddler Jam portal subscriptions](#subscriptions). The Fiddler Jam portal provides various means to organize, access, and work with submitted logs. The portal allows [account owners]({%slug fj-users%}#portal-users) to set up different roles for the portal users with different access rights.
 
 
 ## Portal Users
@@ -16,7 +16,7 @@ The [Fiddler Jam portal](https://jam.getfiddler.com) is the cloud space where lo
 The Fiddler Jam login accepts using custom credentials or Google authentication, but the portal will be accessible only for usernames/emails that are part of an active subscription. Depending on the user assigned role, the Fiddler Jam portal will provide a different level of accessibility and features as follows:
 
 - Unregistered users won't be able to open the Fiddler Jam portal or load generated Fiddler Jam links. Note that no registration is needed to use the Fiddler Jam Chrome extension.
-- Registered users with the **viewer** role can see only logs added to a workspace. If a viewer opens a public link, a page will inform the user that the links need to be added to the account workspace.
+- Registered users with the **viewer** role can see only logs [added to a workspace]({%slug fj-workspaces%}#add-submitted-log-to-workspace). If a viewer opens a public link, a page will inform the user that the links need to be added to the account workspace.
 - Registered users with the **agent** role can open public logs, create and manage workspaces, manage existing logs (manage, add and remove from workspaces).
 
 Learn more about :
@@ -28,7 +28,7 @@ Learn more about :
 
 ## Using Submitted Logs
 
-The Fiddler Jam portal allows organizing, accessing, and reusing the log submitted by an extension user. Logs can be added to workspaces, edited, shared, downloaded, or opened directly in Fiddler Everywhere for in-depth analysis.
+The Fiddler Jam portal allows organizing, accessing, and reusing the logs submitted from the Fiddler Jam extension. Logs can be added to workspaces, edited, shared, downloaded, or opened directly in [Fiddler Everywhere](https://docs.telerik.com/fiddler-everywhere/introduction) for in-depth analysis.
 
 Learn more about:
 - [The portal workspaces]({%slug fj-workspaces%})

--- a/portal/portal-logs.md
+++ b/portal/portal-logs.md
@@ -12,13 +12,13 @@ Once an extension user submits recorded traffic, the log is uploaded to the Fidd
 
 ## Open Submitted Logs
 
-After an extension user submits a log, the log is uploaded to the Fiddler Jam cloud space. At this moment, only the extension users know the exact address of the log. The next step is for the extension user to share the generated link (with the access rules set via [the link generation options]({%slug fj-link-options%})) to the portal user (e.g., a support engineer with Fiddler Jam subscription and agent role).
+After an extension user submits a log, the log is uploaded to the Fiddler Jam cloud space. At this moment, only the extension user knows the exact address of the log. The next step is for the extension user to share the generated link (with the access rules set via [the link generation options]({%slug fj-link-options%})) with the portal user (e.g., a support engineer with Fiddler Jam subscription and agent role).
 
-Notice that to protect the content of the submitted log, the following rules are in order:
+To protect the content of the submitted log, the following rules apply:
 
-1. The submitted log can only be opened by a portal user that meets the access right requirements set by the extension user via [the link generation options]({%slug fj-link-options%}))
+1. The submitted log can only be opened by a portal user who meets the access right requirements set by the extension user via [the link generation options]({%slug fj-link-options%})).
 2. Initially, the submitted log can only be opened by a portal user with [the **agent** role]({%slug fj-users%}#agent-role). Quota restrictions apply for the agent opening the log based on the active subscription (refer to the _Reports per month_ row in [the subscription comparison table]({%slug fj-portal%}#subscriptions)).
-3. (_Optional_) Add the submitted log to a workspace. Logs that are not added to a workspace will be automatically deleted after 30 days period. 
+3. (_Optional_) The submitted log can be added to a workspace. Logs that are not added to a workspace will be automatically deleted after 30 days period. 
 
 In order for portal users with a **viewer** role to be able to open the submitted log, the log must be added to a workspace (by an agent), and the extension user should have set an appropriate access level during the link generation.
 
@@ -27,10 +27,10 @@ In order for portal users with a **viewer** role to be able to open the submitte
 Once a submitted log is opened in the Fiddler Jam portal, there are multiple functionalities that the portal UI provides like:
 
 - [Editing log's details](#log-details) (title, description, etc.).
-- [Investigating the log's captured traffic in details (requests and responses)](#traffic-inspection). 
+- [Investigating the log's captured traffic in detail (requests and responses)](#traffic-inspection). 
 - [Inspecting the taken screenshots](#screenshot-inspection).
 - [Analyzing the developer's console logs](#console-log-inspection).
-- [Reload JAM log for mocking](#mocking-log).
+- [Reload the JAM log for mocking](#mocking-log).
 - [Deep dive investigation through Fiddler Everywhere]({%slug fj-advanced-analysis%}#fiddler-everywhere-integration).
 - [Exporting as HAR file]({%slug fj-advanced-analysis%}#export-har).
 - [Adding submitted logs to organizational workspaces]({%slug fj-workspaces%}#Aadd-submitted-log-to-workspace).
@@ -38,13 +38,13 @@ Once a submitted log is opened in the Fiddler Jam portal, there are multiple fun
 
 ## Log Details
 
-To edit new submitted log details:
+To edit the log details of a newly submitted log:
 
 - Open the submitted log and click on **Add to Workspace**.
 - In the prompted window, edit the log details (_title_, _description_, _submitted by_, _workspace_).
 - Click **Done** when ready. The log will be added to the selected workspace with the new details.
 
-To edit the details of a log added in a workspace:
+To edit the details of a log that is already added in a workspace:
 
 - Open the submitted log from the workspace.
 - Click on the **Edit Log Details** icon (top-right corner next to _Open Workspace_).
@@ -54,13 +54,13 @@ To edit the details of a log added in a workspace:
 
 ## Using Logs
 
-Depending on [the capture options]({%slug fj-capture-options%}), a Fiddler Jam log could contain the captured traffic (sessions), screenshots, and developer's console logs.
+Depending on the selected [capture options]({%slug fj-capture-options%}), a Fiddler Jam log could contain the captured traffic (sessions), screenshots, and developer's console logs.
 
 ### Traffic Inspection
 
-Each FIddler Jam log contains a list of captured HTTP sessions and request/response inspectors. On the left side, called **Captured Logs**, the UI provides the list of captured HTTP sessions, screenshots, and console logs. On the right side, called **Inspectors**, the Fiddler Jam UI provides the **Request** and the **Response** inspectors (when an HTTP session is selected) or the screenshot/console logs preview screen (when a screenshot or a console log is selected).
+Each FIddler Jam log contains a list of captured HTTP sessions and request/response inspectors. On the left side, called **Captured Logs**, the UI provides the list of captured HTTP sessions, screenshots, and console logs. On the right side, called **Inspectors**, the Fiddler Jam UI provides the **Request** and**Response** inspectors (when an HTTP session is selected) or the screenshot/console logs preview screen (when a screenshot or a console log is selected).
 
-To investigate specific HTTP session:
+To investigate a specific HTTP session:
 - Open the submitted log.
 - Select a session line. 
     >tip Each captured HTTP(S) session has a unique line ID which can be used as a reference in both the Fiddler Jam portal and the Fiddler Everywhere desktop application.
@@ -83,7 +83,7 @@ In case the extension user has explicitly enabled the screenshot capturing, a Fi
 
 ### Console Log Inspection
 
-In case the extension user has explicitly enabled the developer's console logs capturing a Fiddler Jam log will also contain console log lines.
+In case the extension user has explicitly enabled the developer's console logs capturing, a Fiddler Jam log will also contain console log lines.
 
 - Select a console log line in the Captured Logs list. The console log loads in a custom inspector.
 - Use the **Details** inspector for examining the console log.

--- a/portal/users.md
+++ b/portal/users.md
@@ -17,14 +17,14 @@ Everyone who uses the Fiddler Jam Chrome extension can be described as an extens
 - There is no limitation on the number of recorded logs.
 - There is no limitation for the number of generated links to recorded logs.
 - A recorded log with a generated link will be stored in the Fiddler Jam portal for **30 days.** After that period, the log will be automatically deleted.
-- A recorded log with generated link **that is added to a workspace** (by an agent) will be stored in the Fiddler Jam portal until it is explicitly removed (by an agent).
+- A recorded log with a generated link **that is added to a workspace** by an agent will be stored in the Fiddler Jam portal until it is explicitly removed by an agent.
 
 ## Portal users
 
- All users who have an active Fiddler Jam license can be referred to as Fiddler Jam portal users. Those users can have different roles based on the license seats.
+All users who have an active Fiddler Jam [subscription]({%slug fj-portal%}#subscriptions) can be referred to as Fiddler Jam portal users. Those users can have different roles based on the available seats in the subscription.
 
 - [**Viewer role**](#viewer-role): The viewer can open **submitted logs** added to a workspace.
-- [**Agent role**](#agent-role): The agent can view, and maintain **submitted logs** and **workspaces** based on the Fiddler Jam account quota.
+- [**Agent role**](#agent-role): The agent can view and maintain **submitted logs** and **workspaces** based on the Fiddler Jam account quota.
 - **Account owner**: The user who purchased the Fiddler Jam license from [the Fiddler dashboard](https://dashboard.getfiddler.com/). This role manages the subscription seats, payment, and assigning the **agent** or **viewer** roles.
 
 
@@ -34,7 +34,7 @@ All subscription plans are coming with unlimited seats for assigning viewer role
 
 The viewer role comes with the following advantages and limitations:
 
-- The viewer can access all logs that are added to the organization workspace. Password-protected logs can only be accessed from a viewer with knowledge of the password.
+- The viewer can access all logs that are added to the organization's workspace. Password-protected logs can only be accessed from a viewer who has the password.
 - The viewer can't access logs not added to a workspace.
 - The viewer can't edit and remove logs added to the workspace.
 
@@ -45,8 +45,8 @@ Depending on the subscription plan, each license will provide a different number
 
 The agent role comes with the following advantages and limitations:
 
-- The agent can access all logs that are added to the account workspace. Password-protected logs can only be accessed from an agent with knowledge of the password.
+- The agent can access all logs that are added to the account workspace. Password-protected logs can only be accessed from an agent who has the password.
 - The agent can access logs not added to a workspace.
 - The agent can edit and remove logs added to the workspace.
 - The agent can add shared logs to a workspace. Logs added to a workspace will be accessible to all viewers.
-- Logs shared with specific agents (based on the registered email) can be accessed from all users with access to the workspace.
+- Logs [shared with specific agents]({%slug fj-link-options%}#share-with-specific-people) (based on the registered email) can be accessed from all users with access to the workspace.

--- a/portal/workspaces.md
+++ b/portal/workspaces.md
@@ -8,28 +8,11 @@ position: 30
 
 # Workspaces
 
-The Fiddler Jam portal uses workspaces to save and organize the submitted logs. With workspaces, you can manage teams, and permissions based on your organization or requirement. Only portal users with the [**agent role**]({%slug fj-users%}#agent-role) can create, edit, delete a workspace and add newly submitted logs to an existing workspace. Users with the [**viewer role**]({%slug fj-users%}#viewer-role) can only access and review logs added to the account workspace.
+The Fiddler Jam portal uses workspaces to save and organize the submitted logs. With workspaces, you can manage teams and permissions based on your organization or requirements. Only portal users with the [**agent role**]({%slug fj-users%}#agent-role) can create, edit, delete a workspace and add newly submitted logs to an existing workspace. Users with the [**viewer role**]({%slug fj-users%}#viewer-role) can only access and review logs added to the account's workspace.
 
-## Add Submitted Log to Workspace
+## Create and Rename Workspace
 
-Any log submitted by an extension user is initially accessible based on [the predefined link generation options]({%slug fj-link-options%}). When an agent (with access right) opens the submitted link initially, it won't be part of any workspace. Submitted logs that are not added to a workspace will expire within 30 days. Logs added to an organizational workspace won't expire and can only be removed by the organization agents.
-
-An agent can add the submitted log to the workspace as follows:
-
-- Use the **Add To Workspace** button in the top-right corner of the dashboard. Note that password-protected logs will require entering the log password before the action is executed.
-- Enter the following details
-    1. **Title**: The input will appear as a log title in the workspace log list.
-    2. **Description** (_Optional_): The input will appear as a log description in the workspace log list.
-    3. **Submitted by**: The input will appear as the log creator alongside the submission date.
-    4. **Workspace**: Choose from a drop-down list of existing organizational workspaces.
-- Click on **Done**. You will see a confirmation notification, and the log will be loaded in the selected workspace on success. Note that password-protected logs will require entering the log password after the action is executed.
-- (Optional) Open the workspace to review the list entry via the **Open Workspace** button or directly continue to work with the submitted log.
-
-![Add submitted log to existing workspace](../images/portal/workspaces/fj-portal-add-to-workspace.png)
-
-## Workspace Name
-
-Each Fiddlem Jam subscription creates a default workspace for the organization called **_<subscription-type> Workspace_** (for example, **_Trial Workspace_** or **_Pro Workspace_**). 
+Each Fiddler Jam subscription automatically creates a default workspace for the organization called **_<subscription-type> Workspace_** (for example, **_Trial Workspace_** or **_Pro Workspace_**). 
 
 An agent can rename the default workspace name as follows:
 
@@ -39,3 +22,19 @@ An agent can rename the default workspace name as follows:
 
 >tip The current version of the Fiddler Jam dashboard doesn't allow creating additional workspaces. Please contact us directly if you need to create more than one workspace.
 
+## Add Submitted Log to Workspace
+
+Any log submitted by an [extension user]({%slug fj-users%}##extension-users) is initially accessible based on [the predefined link generation options]({%slug fj-link-options%}). When an agent (with access right) opens the submitted link initially, it won't be part of any workspace. Submitted logs that are not added to a workspace will expire within 30 days. Logs added to an organizational workspace won't expire and can only be removed by the organization's agents.
+
+An agent can add the submitted log to the workspace as follows:
+
+- Use the **Add To Workspace** button in the top-right corner of the dashboard. Note that password-protected logs will require entering the log password before the action is executed.
+- Enter the following details:
+    1. **Title**: The input will appear as a log title in the workspace log list.
+    2. **Description** (_Optional_): The input will appear as a log description in the workspace log list.
+    3. **Submitted by**: The input will appear as the log creator alongside the submission date.
+    4. **Workspace**: Choose from a drop-down list of existing organizational workspaces.
+- Click on **Done**. You will see a confirmation notification, and the log will be loaded in the selected workspace on success. Note that password-protected logs will require entering the log password after the action is executed.
+- (Optional) Open the workspace to review the listed new log entry via the **Open Workspace** button or directly continue to work with the submitted log.
+
+![Add submitted log to existing workspace](../images/portal/workspaces/fj-portal-add-to-workspace.png)


### PR DESCRIPTION
This PR contains the second set of documents that I reviewed and the corresponding suggestions.
Overall, great work on the documentation!

After going through all documents, I have several questions. I think there are no explicit answers to these questions in the Fiddler Jam articles:

- How do you become a portal user so that you can just view a log? Assume I am a Fiddler Jam user and want to open the link that I am sending. Is it possible? Can I start a trial for this purpose?
- https://testdocs.telerik.com/fiddler-jam/portal/users, line 44 -> What is an existing account? How do you create a new account in the Jam portal?
- Can a Jam extension user share logs with a Jam portal viewer? What will happen?
- _Logs shared with specific agents (based on the registered email) can be accessed from all users with access to the workspace._ Does it mean that viewers can access these logs if these logs aren't explicitly added to the workspace? (in users.md).
- Can a viewer access logs that fulfill all of the following criteria:
	- Are shared by an extension user with specific portal users, but the viewer isn't among them.
	- The logs are shared with an agent in the same workspace as the viewer.
	- The agent has added the logs to the workspace.