### PR TITLE
fix: use correct path for jam embedded service worker

### DIFF
--- a/portal/jam-embedded-api.md
+++ b/portal/jam-embedded-api.md
@@ -110,7 +110,7 @@ The following code snippets demonstrate a basic Fiddler Jam Embedded implementat
 If no file path is provided through the `serviceWorkerPath` argument, then the `service-worker.js` file must be on the same level as the `index.html` file below.
 
 ```JavaScript
-self.importScripts(`https://downloads.getfiddler.com/jam-embedded/fiddler-jam-embedded.js`);
+self.importScripts(`https://downloads.getfiddler.com/jam-embedded/fje-service-worker.js`);
 ```
 
 The following snippet creates a basic HTML page that utilizes most of the Fiddler Jam Embedded functionalities. Different browsers, like Edge, Chrome, Brave, and other non-Chromium browsers such as Firefox and Safari, may show behavioral differences.


### PR DESCRIPTION
The code that needs to be placed in the service worker is available on two locations in the page. However, on the first one the snippet contains incorrect path - instead of using the path to the service-worker, it has the client-side path.